### PR TITLE
Commission api feature

### DIFF
--- a/bestofbooks/pom.xml
+++ b/bestofbooks/pom.xml
@@ -112,6 +112,11 @@
 				<groupId>org.sonarsource.scanner.maven</groupId>
 				<artifactId>sonar-maven-plugin</artifactId>
 				<version>3.4.0.905</version>
+				<configuration>
+					<sonar.test.exclusions>
+						**/test/*
+					</sonar.test.exclusions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/bestofbooks/src/main/java/tqs/group4/bestofbooks/repository/CommissionRepository.java
+++ b/bestofbooks/src/main/java/tqs/group4/bestofbooks/repository/CommissionRepository.java
@@ -8,5 +8,5 @@ import tqs.group4.bestofbooks.model.Commission;
 @Repository
 public interface CommissionRepository extends JpaRepository<Commission, Integer> {
     @Query(value = "SELECT SUM(amount) FROM commissions", nativeQuery = true)
-    double totalAmount();
+    Double totalAmount();
 }

--- a/bestofbooks/src/main/java/tqs/group4/bestofbooks/repository/CommissionRepository.java
+++ b/bestofbooks/src/main/java/tqs/group4/bestofbooks/repository/CommissionRepository.java
@@ -7,6 +7,6 @@ import tqs.group4.bestofbooks.model.Commission;
 
 @Repository
 public interface CommissionRepository extends JpaRepository<Commission, Integer> {
-    @Query(value = "SELECT SUM(amount) FROM commissions", nativeQuery = true)
+    @Query(value = "SELECT COALESCE(SUM(amount), 0) FROM commissions", nativeQuery = true)
     Double totalAmount();
 }

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/controller/AdminControllerTest.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/controller/AdminControllerTest.java
@@ -1,0 +1,70 @@
+package tqs.group4.bestofbooks.controller;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import tqs.group4.bestofbooks.mocks.BookMocks;
+import tqs.group4.bestofbooks.mocks.CommissionMocks;
+import tqs.group4.bestofbooks.service.BookService;
+import tqs.group4.bestofbooks.service.CommissionService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tqs.group4.bestofbooks.utils.Json.toJson;
+
+@WebMvcTest(AdminController.class)
+class AdminControllerTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private CommissionService commissionService;
+
+    @AfterEach
+    public void after() {
+        reset(commissionService);
+    }
+
+    @Test
+    void getCommissions() {
+    }
+
+    @Test
+    void givenCommissions_thenGetCommissionsTotal() throws Exception {
+        Double allCommissions = CommissionMocks.commission1.getAmount() +  CommissionMocks.commission2.getAmount();
+        String url = "/api/admin/commissions/total";
+        given(commissionService.getCommissionsTotal()).willReturn(allCommissions);
+        mvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status()
+                .isOk())
+                .andExpect(content().json(toJson(allCommissions)));
+        verify(commissionService, VerificationModeFactory.times(1)).getCommissionsTotal();
+    }
+
+    @Test
+    void givenNoCommissions_thenGetZeroAsTotal() throws Exception {
+        Double allCommissions = 0.0;
+        String url = "/api/admin/commissions/total";
+        given(commissionService.getCommissionsTotal()).willReturn(allCommissions);
+        mvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status()
+                .isOk())
+                .andExpect(content().json(toJson(allCommissions)));
+        verify(commissionService, VerificationModeFactory.times(1)).getCommissionsTotal();
+    }
+
+
+
+}

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/controller/AdminControllerTest.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/controller/AdminControllerTest.java
@@ -1,15 +1,22 @@
 package tqs.group4.bestofbooks.controller;
 
+import com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import tqs.group4.bestofbooks.mocks.BookMocks;
 import tqs.group4.bestofbooks.mocks.CommissionMocks;
+import tqs.group4.bestofbooks.model.Book;
+import tqs.group4.bestofbooks.model.Commission;
 import tqs.group4.bestofbooks.service.BookService;
 import tqs.group4.bestofbooks.service.CommissionService;
 
@@ -65,6 +72,20 @@ class AdminControllerTest {
         verify(commissionService, VerificationModeFactory.times(1)).getCommissionsTotal();
     }
 
+    @Test
+    void givenCommissions_thenGetAllCommissions() throws Exception {
+        Pageable p = PageRequest.of(0, 20);
+        Page<Commission> commissionPage = new PageImpl<>(Lists.newArrayList(CommissionMocks.commission1,
+                CommissionMocks.commission2), p, 2);
 
+        given(commissionService.getCommissions(p)).willReturn(commissionPage);
 
+        String url = "/api/admin/commissions/";
+
+        mvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status()
+                .isOk())
+           .andExpect(content().json(toJson(commissionPage)));
+    }
 }

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/integration/AdminControllerIT.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/integration/AdminControllerIT.java
@@ -1,5 +1,6 @@
 package tqs.group4.bestofbooks.integration;
 
+import com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -7,11 +8,18 @@ import org.mockito.internal.verification.VerificationModeFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import tqs.group4.bestofbooks.BestofbooksApplication;
+import tqs.group4.bestofbooks.mocks.BookMocks;
 import tqs.group4.bestofbooks.mocks.CommissionMocks;
+import tqs.group4.bestofbooks.model.Book;
 import tqs.group4.bestofbooks.model.Commission;
+import tqs.group4.bestofbooks.model.Order;
 
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
@@ -21,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tqs.group4.bestofbooks.mocks.BuyerMock.buyer1;
 import static tqs.group4.bestofbooks.utils.Json.toJson;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -34,43 +43,75 @@ public class AdminControllerIT {
     @Autowired
     private EntityManager entityManager;
 
+    private Commission commission1;
+    private Commission commission2;
+    private Order order1;
+    private Order order2;
 
-    @AfterEach
-    public void after() {
-        entityManager.remove(CommissionMocks.commission1);
-        entityManager.remove(CommissionMocks.commission2);
-        entityManager.flush();
+    @BeforeEach
+    public void before() {
+        entityManager.createNativeQuery("TRUNCATE books, orders, commissions, admin, books_orders, revenues").executeUpdate();
+        entityManager.createNativeQuery("ALTER SEQUENCE orders_id_seq RESTART WITH 1").executeUpdate();
+        order1 = new Order("AC%EWRGER684654165",
+                "77th st no 21, LA, CA, USA",
+                10.00,
+                buyer1);
+        order2 = new Order("AC%EWRGER684654164",
+                "77th st no 21, LA, CA, USA",
+                20.00,
+                buyer1);
+        commission1 = new Commission(2.00, 1);
+        commission2 = new Commission(4.00, 2);
     }
 
     @Test
     void givenCommissions_thenGetCommissionsTotal() throws Exception {
-        entityManager.persist(CommissionMocks.commission1);
-        entityManager.persist(CommissionMocks.commission2);
-
+        entityManager.persist(order1);
+        entityManager.persist(order2);
+        entityManager.persist(commission1);
+        entityManager.persist(commission2);
         entityManager.flush();
-        Double allCommissions = CommissionMocks.commission1.getAmount() +  CommissionMocks.commission2.getAmount();
+
+        Double expectedTotal = commission1.getAmount() + commission2.getAmount();
         String url = "/api/admin/commissions/total";
 
         mvc.perform(get(url)
                 .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status()
                 .isOk())
-                .andExpect(content().json(toJson(allCommissions)));
+                .andExpect(content().json(toJson(expectedTotal)));
 
     }
 
     @Test
     void givenNoCommissions_thenGetZeroAsTotal() throws Exception {
-        entityManager.persist(CommissionMocks.commission1);
-        entityManager.persist(CommissionMocks.commission2);
-
-        entityManager.flush();
-        Double allCommissions = 0.0;
+        Double expectedTotal = 0.00;
         String url = "/api/admin/commissions/total";
         mvc.perform(get(url)
                 .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status()
                 .isOk())
-                .andExpect(content().json(toJson(allCommissions)));
+                .andExpect(content().json(toJson(expectedTotal)));
+    }
+
+    @Test
+    void givenCommissions_thenGetAllCommissions() throws Exception {
+        entityManager.persist(order1);
+        entityManager.persist(order2);
+        entityManager.persist(commission1);
+        entityManager.persist(commission2);
+        entityManager.flush();
+
+        Pageable p = PageRequest.of(0, 20);
+        Page<Commission> commissionPage = new PageImpl<>(Lists.newArrayList(commission1, commission2), p, 2);
+
+        String url = "/api/admin/commissions/";
+
+        mvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status()
+                .isOk())
+           .andExpect(content().json(toJson(commissionPage)));
+
     }
 }

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/integration/AdminControllerIT.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/integration/AdminControllerIT.java
@@ -1,0 +1,76 @@
+package tqs.group4.bestofbooks.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import tqs.group4.bestofbooks.BestofbooksApplication;
+import tqs.group4.bestofbooks.mocks.CommissionMocks;
+import tqs.group4.bestofbooks.model.Commission;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tqs.group4.bestofbooks.utils.Json.toJson;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = BestofbooksApplication.class)
+@AutoConfigureMockMvc
+@Transactional
+public class AdminControllerIT {
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+
+    @AfterEach
+    public void after() {
+        entityManager.remove(CommissionMocks.commission1);
+        entityManager.remove(CommissionMocks.commission2);
+        entityManager.flush();
+    }
+
+    @Test
+    void givenCommissions_thenGetCommissionsTotal() throws Exception {
+        entityManager.persist(CommissionMocks.commission1);
+        entityManager.persist(CommissionMocks.commission2);
+
+        entityManager.flush();
+        Double allCommissions = CommissionMocks.commission1.getAmount() +  CommissionMocks.commission2.getAmount();
+        String url = "/api/admin/commissions/total";
+
+        mvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status()
+                .isOk())
+                .andExpect(content().json(toJson(allCommissions)));
+
+    }
+
+    @Test
+    void givenNoCommissions_thenGetZeroAsTotal() throws Exception {
+        entityManager.persist(CommissionMocks.commission1);
+        entityManager.persist(CommissionMocks.commission2);
+
+        entityManager.flush();
+        Double allCommissions = 0.0;
+        String url = "/api/admin/commissions/total";
+        mvc.perform(get(url)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status()
+                .isOk())
+                .andExpect(content().json(toJson(allCommissions)));
+    }
+}

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/integration/AdminControllerIT.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/integration/AdminControllerIT.java
@@ -112,6 +112,5 @@ public class AdminControllerIT {
         ).andExpect(status()
                 .isOk())
            .andExpect(content().json(toJson(commissionPage)));
-
     }
 }

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/repository/CommissionRepositoryTest.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/repository/CommissionRepositoryTest.java
@@ -1,0 +1,48 @@
+package tqs.group4.bestofbooks.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import tqs.group4.bestofbooks.model.Commission;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class CommissionRepositoryTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private CommissionRepository commissionRepository;
+
+    @BeforeEach
+    public void before() {
+        entityManager.createNativeQuery("TRUNCATE books, orders, commissions, admin, books_orders, revenues").executeUpdate();
+    }
+
+    @Test
+    void givenCommissions_recieveTotalAmount() {
+        Commission commission =  new Commission(120.1, 40);
+        Commission commission2 =  new Commission(121.1, 41);
+
+        entityManager.persist(commission);
+        entityManager.persist(commission2);
+
+        entityManager.flush();
+        Double result = commissionRepository.totalAmount();
+        assertEquals(commission.getAmount() + commission2.getAmount(), result);
+        entityManager.remove(commission);
+        entityManager.remove(commission2);
+
+        entityManager.flush();
+
+    }
+
+
+}

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/repository/CommissionRepositoryTest.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/repository/CommissionRepositoryTest.java
@@ -4,12 +4,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import tqs.group4.bestofbooks.model.Commission;
+import tqs.group4.bestofbooks.model.Order;
 
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static tqs.group4.bestofbooks.mocks.BuyerMock.buyer1;
 
 @SpringBootTest
 @Transactional
@@ -21,28 +26,53 @@ class CommissionRepositoryTest {
     @Autowired
     private CommissionRepository commissionRepository;
 
+    private Commission commission1;
+    private Commission commission2;
+    private Order order1;
+    private Order order2;
+
     @BeforeEach
     public void before() {
         entityManager.createNativeQuery("TRUNCATE books, orders, commissions, admin, books_orders, revenues").executeUpdate();
+        entityManager.createNativeQuery("ALTER SEQUENCE orders_id_seq RESTART WITH 1").executeUpdate();
+        order1 = new Order("AC%EWRGER684654165",
+                "77th st no 21, LA, CA, USA",
+                10.00,
+                buyer1);
+        order2 = new Order("AC%EWRGER684654164",
+                "77th st no 21, LA, CA, USA",
+                20.00,
+                buyer1);
+        commission1 = new Commission(2.00, 1);
+        commission2 = new Commission(4.00, 2);
     }
 
     @Test
-    void givenCommissions_recieveTotalAmount() {
-        Commission commission =  new Commission(120.1, 40);
-        Commission commission2 =  new Commission(121.1, 41);
-
-        entityManager.persist(commission);
+    void givenCommissions_receiveTotalAmount() {
+        entityManager.persist(order1);
+        entityManager.persist(order2);
+        entityManager.persist(commission1);
         entityManager.persist(commission2);
-
-        entityManager.flush();
-        Double result = commissionRepository.totalAmount();
-        assertEquals(commission.getAmount() + commission2.getAmount(), result);
-        entityManager.remove(commission);
-        entityManager.remove(commission2);
-
         entityManager.flush();
 
+        Double queryResult = commissionRepository.totalAmount();
+        assertEquals(commission1.getAmount() + commission2.getAmount(), queryResult);
     }
 
+    @Test
+    void givenCommissions_fetchCommissionsPage() {
+        entityManager.persist(order1);
+        entityManager.persist(order2);
+        entityManager.persist(commission1);
+        entityManager.persist(commission2);
+        entityManager.flush();
 
+        Pageable p = PageRequest.of(0, 20);
+
+        Page<Commission> queryResults = commissionRepository.findAll(p);
+        assertAll("findAllCommissions",
+                () -> assertTrue(queryResults.getContent().contains(commission1)),
+                () -> assertTrue(queryResults.getContent().contains(commission2))
+        );
+    }
 }

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/repository/CommissionRepositoryTest.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/repository/CommissionRepositoryTest.java
@@ -60,6 +60,12 @@ class CommissionRepositoryTest {
     }
 
     @Test
+    void givenNoCommissions_receiveTotalAmountAsZero() {
+        Double queryResult = commissionRepository.totalAmount();
+        assertEquals(0.00, queryResult);
+    }
+
+    @Test
     void givenCommissions_fetchCommissionsPage() {
         entityManager.persist(order1);
         entityManager.persist(order2);

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/service/CommissionServiceTests.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/service/CommissionServiceTests.java
@@ -1,17 +1,26 @@
 package tqs.group4.bestofbooks.service;
 
+import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import tqs.group4.bestofbooks.mocks.BookMocks;
 import tqs.group4.bestofbooks.mocks.CommissionMocks;
 import tqs.group4.bestofbooks.mocks.OrderMocks;
+import tqs.group4.bestofbooks.model.Book;
 import tqs.group4.bestofbooks.model.Commission;
 import tqs.group4.bestofbooks.repository.AdminRepository;
 import tqs.group4.bestofbooks.repository.CommissionRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
 import static tqs.group4.bestofbooks.service.CommissionService.COMMISSION_PERCENTAGE;
 
 public class CommissionServiceTests {
@@ -26,12 +35,28 @@ public class CommissionServiceTests {
         MockitoAnnotations.initMocks(this);
     }
 
-    // Still missing 2 feature tests
+    @Test
+    void whenAllCommissionsAreRequested_getCommissionsPage() {
+        Pageable p = PageRequest.of(0, 20);
+        Page<Commission> commissionPage = new PageImpl<>(Lists.newArrayList(CommissionMocks.commission1,
+                CommissionMocks.commission2), p, 2);
+
+        when(commissionRepository.findAll(p)).thenReturn(commissionPage);
+
+        Page<Commission> returned = service.getCommissions(p);
+        assertEquals(commissionPage, returned);
+    }
 
     @Test
-    void getCommissionTotal() {
-        //Failing test
-        assertEquals(CommissionMocks.commission1.getAmount(),service.getCommissionsTotal());
+    void whenThereAreCommissionsPresent_getCommissionTotal() {
+        when(commissionRepository.totalAmount()).thenReturn(500.50);
+        assertEquals(500.50, service.getCommissionsTotal());
+    }
+
+    @Test
+    void whenThereAreNoCommissionsPresent_getCommissionTotalIsNull() {
+        when(commissionRepository.totalAmount()).thenReturn(null);
+        assertNull(service.getCommissionsTotal());
     }
 
     @Test

--- a/bestofbooks/src/test/java/tqs/group4/bestofbooks/service/CommissionServiceTests.java
+++ b/bestofbooks/src/test/java/tqs/group4/bestofbooks/service/CommissionServiceTests.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import tqs.group4.bestofbooks.mocks.CommissionMocks;
 import tqs.group4.bestofbooks.mocks.OrderMocks;
+import tqs.group4.bestofbooks.model.Commission;
+import tqs.group4.bestofbooks.repository.AdminRepository;
 import tqs.group4.bestofbooks.repository.CommissionRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,6 +27,12 @@ public class CommissionServiceTests {
     }
 
     // Still missing 2 feature tests
+
+    @Test
+    void getCommissionTotal() {
+        //Failing test
+        assertEquals(CommissionMocks.commission1.getAmount(),service.getCommissionsTotal());
+    }
 
     @Test
     void testComputeCommissionAmountByOrderResults() {


### PR DESCRIPTION
Esta branch correspondente às 2 user stories seguintes:

- Admin consulta o histórico de comissões - API
-  Admin consulta o valor total de comissões da plataforma. - API

Já tinham sido desenvolvidas no último sprint, mas não se encontravam cobertas por testes (apenas a componente referente às Orders), pelo que a entrega será só feita agora.

A nível de funcionalidade, preenchem os critérios de aceitação definidos, como mostram os resultados do postman:
![Screenshot from 2020-05-24 10-50-39](https://user-images.githubusercontent.com/44161408/82752810-98b89b80-9db8-11ea-9c4d-667acb175fe8.png)

![Screenshot from 2020-05-24 10-50-51](https://user-images.githubusercontent.com/44161408/82752816-a2420380-9db8-11ea-8196-b9b2ed977814.png)

Relativamente a QA, os resultados são os seguintes:
![Screenshot from 2020-05-24 11-57-46](https://user-images.githubusercontent.com/44161408/82752831-b71e9700-9db8-11ea-931f-38af5aaa789c.png)
Esses code smells todos que aparecem é porque o SonarQube não está a excluir os ficheiros da pasta test da análise e está-se a queixar a de problemas relativo ao código de testes, não de implementação, como se pode ver abaixo:
![Screenshot from 2020-05-24 12-01-53](https://user-images.githubusercontent.com/44161408/82752853-e7663580-9db8-11ea-9821-5ff7f8df683f.png)

Para tentar resolver este problema, eu coloquei a mesma configuração que usei para a análise de SonarQube de CI na master:
![Screenshot from 2020-05-24 12-13-54](https://user-images.githubusercontent.com/44161408/82752869-0238aa00-9db9-11ea-9047-fe86ff883eb4.png)
![Screenshot from 2020-05-24 12-14-59](https://user-images.githubusercontent.com/44161408/82752871-05339a80-9db9-11ea-9a20-876abc1eff87.png)
Mas o pom.xml da branch commission_api_feature, apesar de ser igualzinho ao da master e de já ter experimentado fazer merge do pom.xml da master, não está a ser reconhecido na minha ide, o que me parece ser bug do pom.xml.

Queria experimentar ver os resultados da static code analysis que será despoletada pull request, se vão funcionar e excluir a análise de código de testes.